### PR TITLE
draft: an attempt at making things *not* update the entire array list

### DIFF
--- a/src-theme/src/routes/hud/elements/ArrayList.svelte
+++ b/src-theme/src/routes/hud/elements/ArrayList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import {onMount, tick} from "svelte";
     import type {Module} from "../../../integration/types";
-    import {getModules} from "../../../integration/rest";
+    import {getModule, getModules} from "../../../integration/rest";
     import {listen} from "../../../integration/ws";
     import {getTextWidth} from "../../../integration/text_measurement";
     import {flip} from "svelte/animate";
@@ -10,24 +10,46 @@
 
     let enabledModules: Module[] = [];
 
+    function sortByWidth(modules: Module[]): Module[] {
+        return modules.map(m => {
+                let formattedName = $spaceSeperatedNames ? convertToSpacedString(m.name) : m.name;
+                let fullName = m.tag == null ? formattedName : formattedName + " " + m.tag;
+
+                return {
+                    ...m,
+                    width: getTextWidth(fullName, "500 14px Inter")
+                };
+            }
+        ).toSorted((a, b) => b.width - a.width).map(a => { // remove width property because yes
+            a.width = undefined as unknown as number;
+            return a;
+        });
+    }
+
     async function updateEnabledModules() {
         const modules = await getModules();
         const visibleModules = modules.filter(m => m.enabled && !m.hidden);
 
-        const modulesWithWidths = visibleModules.map(module => {
-                let formattedName = $spaceSeperatedNames ? convertToSpacedString(module.name) : module.name;
-                let fullName = module.tag == null ? formattedName : formattedName + " " + module.tag;
-
-                return {
-                    ...module,
-                    width: getTextWidth(fullName, "500 14px Inter")
-                };
+        enabledModules = sortByWidth(visibleModules);
+        await tick();
+    }
+    async function updateModule(modName: string) {
+        const m = await getModule(modName);
+        if (!m.enabled || m.hidden) {
+            const index = enabledModules.indexOf(m);
+            if (index > -1) {
+                enabledModules.splice(index, 1);
             }
-        );
+        }
 
-        modulesWithWidths.sort((a, b) => b.width - a.width);
 
-        enabledModules = modulesWithWidths;
+        const index = enabledModules.indexOf(m);
+        if (index !== -1) {
+            enabledModules.splice(index, 1);
+            enabledModules[index] = m;
+            // this probably gets rid of 50% of the performance boost...
+            enabledModules = sortByWidth(enabledModules);
+        }
         await tick();
     }
 
@@ -45,6 +67,9 @@
 
     listen("refreshArrayList", async () => {
         await updateEnabledModules();
+    });
+    listen("refreshModuleInArrayList", async (modName: string) => {
+        await updateModule(modName);
     });
 </script>
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/event/events/ClientEvents.kt
@@ -83,6 +83,10 @@ class ModuleToggleEvent(val moduleName: String, val hidden: Boolean, val enabled
 @WebSocketEvent
 object RefreshArrayListEvent : Event()
 
+@Nameable("refreshModuleInArrayList")
+@WebSocketEvent
+class RefreshModuleInArrayListEvent(val moduleName: String) : Event()
+
 @Nameable("notification")
 @WebSocketEvent
 class NotificationEvent(val title: String, val message: String, val severity: Severity) : Event() {

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/ClientModule.kt
@@ -25,10 +25,7 @@ import net.ccbluex.liquidbounce.config.types.*
 import net.ccbluex.liquidbounce.event.EventListener
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.SequenceManager.cancelAllSequences
-import net.ccbluex.liquidbounce.event.events.ModuleActivationEvent
-import net.ccbluex.liquidbounce.event.events.ModuleToggleEvent
-import net.ccbluex.liquidbounce.event.events.NotificationEvent
-import net.ccbluex.liquidbounce.event.events.RefreshArrayListEvent
+import net.ccbluex.liquidbounce.event.events.*
 import net.ccbluex.liquidbounce.features.module.modules.misc.antibot.ModuleAntiBot
 import net.ccbluex.liquidbounce.lang.LanguageManager
 import net.ccbluex.liquidbounce.lang.translation
@@ -153,7 +150,7 @@ open class ClientModule(
         .doNotIncludeWhen { !AutoConfig.includeConfiguration.includeHidden }
         .independentDescription()
         .onChange {
-            EventManager.callEvent(RefreshArrayListEvent)
+            EventManager.callEvent(RefreshModuleInArrayListEvent(name))
             it
         }.apply {
             if (notActivatable) {
@@ -213,7 +210,7 @@ open class ClientModule(
 
         // Refresh arraylist on tag change
         setting.onChanged {
-            EventManager.callEvent(RefreshArrayListEvent)
+            EventManager.callEvent(RefreshModuleInArrayListEvent(name))
         }
     }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/offhand/ModuleOffhand.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/features/module/modules/player/offhand/ModuleOffhand.kt
@@ -23,7 +23,7 @@ import net.ccbluex.liquidbounce.config.types.NamedChoice
 import net.ccbluex.liquidbounce.config.types.ToggleableConfigurable
 import net.ccbluex.liquidbounce.event.EventManager
 import net.ccbluex.liquidbounce.event.events.KeyEvent
-import net.ccbluex.liquidbounce.event.events.RefreshArrayListEvent
+import net.ccbluex.liquidbounce.event.events.RefreshModuleInArrayListEvent
 import net.ccbluex.liquidbounce.event.events.ScheduleInventoryActionEvent
 import net.ccbluex.liquidbounce.event.handler
 import net.ccbluex.liquidbounce.features.module.Category
@@ -162,7 +162,7 @@ object ModuleOffhand : ClientModule("Offhand", Category.PLAYER, aliases = arrayO
         }
 
         if (activeMode != lastTagMode) {
-            EventManager.callEvent(RefreshArrayListEvent)
+            EventManager.callEvent(RefreshModuleInArrayListEvent(name))
             lastTagMode = activeMode
         }
 

--- a/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
+++ b/src/main/kotlin/net/ccbluex/liquidbounce/script/bindings/features/ScriptModule.kt
@@ -21,6 +21,7 @@ package net.ccbluex.liquidbounce.script.bindings.features
 import net.ccbluex.liquidbounce.config.types.Value
 import net.ccbluex.liquidbounce.event.*
 import net.ccbluex.liquidbounce.event.events.RefreshArrayListEvent
+import net.ccbluex.liquidbounce.event.events.RefreshModuleInArrayListEvent
 import net.ccbluex.liquidbounce.features.module.Category
 import net.ccbluex.liquidbounce.features.module.ClientModule
 import net.ccbluex.liquidbounce.script.PolyglotScript
@@ -38,7 +39,7 @@ class ScriptModule(val script: PolyglotScript, moduleObject: Map<String, Any>) :
     override var tag: String? = null
         set(value) {
             field = value
-            EventManager.callEvent(RefreshArrayListEvent)
+            EventManager.callEvent(RefreshModuleInArrayListEvent(name))
         }
 
     private var _description: String? = null


### PR DESCRIPTION
just leaving this out here if anyone wants a reference of what I did, `RefreshArrayListEvent` is actually unused now, but it was kept for script compatibility reasons (even though most scripts won't use it)

## Summary by Sourcery

Optimize module list rendering by introducing a more efficient module update mechanism in the ArrayList component

New Features:
- Introduce a new event `RefreshModuleInArrayListEvent` to update specific modules in the array list

Enhancements:
- Implement a more granular module update approach that allows updating individual modules without refreshing the entire list
- Add sorting and width calculation for modules to improve rendering performance